### PR TITLE
flake.nix: Patch pipewire (pw-mon) in devShell

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+flake.lock linguist-generated

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/dist-newstyle/

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1713721570,
-        "narHash": "sha256-R0s+O5UjTePQRb72XPgtkTmEiOOW8n+1q9Gxt/OJnKU=",
+        "lastModified": 1717196966,
+        "narHash": "sha256-yZKhxVIKd2lsbOqYd5iDoUIwsRZFqE87smE2Vzf6Ck0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b93b4e9b527904aadf52dba6ca35efde2067cbd4",
+        "rev": "57610d2f8f0937f39dbd72251e9614b1561942d8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Hi, I found this project today after searching for "pipewire haskell" and it looks quite promising.

I would like to write Haskell scripts for audio session management - e.g. connecting synths to MIDI ports, hosting plugins, setting a reasonable volume, etc.

Anyway, this PR applies the `pw-mon` patch to pipewire in the nix develop shell, which makes it easier to test `pw-controller`.

Thanks
