### PR TITLE
Add haskellExtend output and update README with guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,26 @@ References:
 - Source entrypoint: [Pipewire.hs](./pipewire/src/Pipewire.hs)
 - Upstream doc: <https://docs.pipewire.org/topics.html>
 
+## Nix
+To use this library in your own Haskell projects that are built with [Nix](https://nixos.org/), this flake provides an output `haskellExtend`, which can be used to extend a collection of Haskell packages in nixpkgs. An example flake structure using this is shown below.
+
+```nix
+# flake.nix
+{
+    inputs = {
+       ...
+       pipewire-hs.url = "github:TristanCacqueray/pipewire.hs;
+       ...
+    };
+
+    outputs = { self, nixpkgs, pipewire-hs, ...}: {
+       ...
+       haskellPackages = pkgs.haskellPackages.extend (pipewire-hs.haskellExtend { pipewire = pkgs.pipewire; });
+       ...
+    };
+}
+
+```
 
 ## Contribute
 

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,14 @@
         pkgs.pkg-config
       ];
     in {
+
+      # An output that allows a user of this flake to extend their
+      # chosen haskell packages set with pipewire and pw-controller.
+      haskellExtend = {pipewire}: hpFinal: hpPrev: {
+        pw-controller = hpPrev.callCabal2nix "pw-controller" ./pw-controller { };
+        pipewire = hpPrev.callCabal2nix "pipewire" ./pipewire { libpipewire = pipewire; };
+      };
+
       devShell.x86_64-linux = hsPkgs.shellFor {
         packages = p: [ p.pw-controller p.pipewire ];
         buildInputs = ciTools ++ devTools;


### PR DESCRIPTION
I have added an output to the flake that allows users to easily extend their chosen Haskell package set. This means that a user can choose to extend different package sets (such as `pkgs.haskell.packages.ghc965`, not just `pkgs.haskellPackages`).

I couldn't get your pipewire package to build when also building the examples, so I haven't included that in the `haskellExtend` output, and just use `callCabal2nix`.

I'm not sure what "the best" way of exposing your libraries are to end users, but I think that this is fairly sensible. 

I'm glad I stumbled upon this project - I had just started looking into using Haskell for audio development so thank you for your work!